### PR TITLE
Fix broken image paths in hare scramble director blog posts

### DIFF
--- a/src/content/blog/2026-06-10-ecea-harescramble-director-and-scoring-positions-are-opening.md
+++ b/src/content/blog/2026-06-10-ecea-harescramble-director-and-scoring-positions-are-opening.md
@@ -5,7 +5,7 @@ description: Important positions opening up for the ECEA Harescramble Series
 author: ECEA
 category: news
 image:
-  src: /assets/blog/ECEA Hare Scrambles Series Director 060826 r1.png
+  src: '../../assets/blog/ECEA Hare Scrambles Series Director 060826 r1.png'
   alt: hs director open position flyer
 tags:
   - harescramble

--- a/src/content/blog/2026-06-10-hare-scramble-director-and-scoring-team-positions-are-opening.md
+++ b/src/content/blog/2026-06-10-hare-scramble-director-and-scoring-team-positions-are-opening.md
@@ -5,7 +5,7 @@ description: Critical positions for the ECEA Hare Scramble series are opening up
 author: ECEA
 category: news
 image:
-  src: /assets/blog/ECEA%20Hare%20Scrambles%20Series%20Director%20060826%20r1.png
+  src: '../../assets/blog/ECEA Hare Scrambles Series Director 060826 r1.png'
   alt: hs director opening flyer
 draft: true
 ---


### PR DESCRIPTION
Changed image src from absolute /assets/blog/ paths to relative ../../assets/blog/ paths so Astro can resolve and process them at build time.