### PR TITLE
fix: eliminate TinaCMS image path build failures permanently

### DIFF
--- a/src/components/Cards/BlogCard.astro
+++ b/src/components/Cards/BlogCard.astro
@@ -16,7 +16,7 @@ interface Props {
   description?: string;
   category?: "announcement" | "news" | "recap" | "article";
   image?: {
-    src: ImageMetadata;
+    src: string;
     alt: string;
   };
   featured?: boolean;
@@ -43,12 +43,21 @@ const {
     className
   ]}
 >
-  <Image
-    src={image?.src ?? defaultBlogImage}
-    alt={image?.alt ?? "ECEA"}
-    class="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
-    widths={featured ? [640, 800] : [400, 600]}
-  />
+  {image?.src ? (
+    <img
+      src={image.src}
+      alt={image.alt}
+      loading="lazy"
+      class="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+    />
+  ) : (
+    <Image
+      src={defaultBlogImage}
+      alt="ECEA"
+      class="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+      widths={featured ? [640, 800] : [400, 600]}
+    />
+  )}
 
   <div class:list={["absolute inset-0", UI_STYLES.gradientOverlay]}></div>
 

--- a/src/components/Cards/EventCard.astro
+++ b/src/components/Cards/EventCard.astro
@@ -4,7 +4,6 @@
  * Displays an event with image, date, type badge, and title
  * Used on homepage and events listing page
  */
-import { Image } from "astro:assets";
 import { formatDate } from "../../utils/dateUtils";
 import { getEventTypeBadgeClassesDark } from "../../utils/eventTypeColors";
 
@@ -14,7 +13,7 @@ interface Props {
   date: Date;
   eventType?: string;
   location?: string;
-  image?: ImageMetadata | null;
+  image?: string | null;
   featured?: boolean;
   class?: string;
 }
@@ -40,11 +39,11 @@ const {
   ]}
 >
   {image ? (
-    <Image
+    <img
       src={image}
       alt={title}
+      loading="lazy"
       class="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
-      widths={featured ? [640, 800] : [400, 600]}
     />
   ) : (
     <div class="absolute inset-0 bg-gradient-to-br from-primary-600 to-primary-800"></div>

--- a/src/components/Sections/SponsorCarousel.astro
+++ b/src/components/Sections/SponsorCarousel.astro
@@ -3,11 +3,9 @@
  * SponsorCarousel Component
  * Displays title sponsor prominently and scrolling carousel of other sponsors
  */
-import { Image } from "astro:assets";
-
 interface Sponsor {
   name: string;
-  logo: ImageMetadata;
+  logo: string;
   url: string;
 }
 
@@ -38,9 +36,10 @@ const { titleSponsor, sponsors } = Astro.props;
           >
             <span class="text-xs uppercase tracking-wider text-gray-500">Title Sponsor</span>
             <div class="bg-white rounded-lg px-4 py-2 border border-gray-200 group-hover:border-primary-300 transition-colors">
-              <Image
+              <img
                 src={titleSponsor.logo}
                 alt={titleSponsor.name}
+                loading="lazy"
                 class="h-10 md:h-12 w-auto object-contain"
               />
             </div>
@@ -59,9 +58,10 @@ const { titleSponsor, sponsors } = Astro.props;
             rel="noopener noreferrer"
             class="flex-shrink-0"
           >
-            <Image
+            <img
               src={sponsor.logo}
               alt={sponsor.name}
+              loading="lazy"
               class="h-8 md:h-10 w-auto object-contain"
             />
           </a>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -6,24 +6,11 @@ import { STAFF_CATEGORIES, BLOG_CATEGORIES, SCHEDULABLE_EVENT_TYPES } from '../u
  * East Coast Enduro Association - Racing Organization
  */
 
-// Helper: TinaCMS Cloud does not apply ui.parse, so it always saves absolute paths
-// like /assets/events/flyers/foo.png. Astro's image() requires relative paths.
-// This preprocessor normalizes absolute /assets/... paths to relative paths
-// based on the content file's depth from src/.
-// Existing relative paths (../../..assets/...) pass through unchanged.
-// Also URL-decodes paths (TinaCMS sometimes saves spaces as %20) so Vite can
-// resolve filenames with spaces on the filesystem.
-const normalizeAssetPath = (depth: number) => (val: unknown) => {
-  if (typeof val === 'string') {
-    if (val === '') return undefined;
-    const decoded = decodeURIComponent(val);
-    if (decoded.startsWith('/assets/')) {
-      return '../'.repeat(depth) + 'assets/' + decoded.slice(8);
-    }
-    return decoded;
-  }
-  return val;
-};
+// NOTE: Image fields use z.string() rather than Astro's image() helper.
+// TinaCMS Cloud saves image paths as absolute strings (/assets/... or /uploads/...).
+// Using z.string() accepts these directly — images are served via the public/assets
+// symlink without any build-time processing. This avoids recurring build failures
+// caused by the path format mismatch between TinaCMS and Astro's image() validator.
 
 // Helper for optional strings that may be empty
 const optionalString = z
@@ -110,11 +97,10 @@ const optionalDate = z
  */
 const clubsCollection = defineCollection({
   type: 'content',
-  schema: ({ image }) =>
-    z.object({
+  schema: z.object({
       name: z.string(),
       abbreviatedName: z.string(),
-      logo: z.preprocess(normalizeAssetPath(2), image().optional()),
+      logo: z.string().optional(),
       summary: z.string().optional(),
       website: z.string().optional(),
       contact: z.string().optional(),
@@ -132,8 +118,7 @@ const clubsCollection = defineCollection({
  */
 const eventsCollection = defineCollection({
   type: 'content',
-  schema: ({ image }) =>
-    z.object({
+  schema: z.object({
       title: z.string(),
       summary: z.string(),
 
@@ -159,9 +144,9 @@ const eventsCollection = defineCollection({
       gasAway: z.boolean().default(false),
       gateFee: z.string().optional(),
 
-      // Media - TinaCMS Cloud saves /assets/... paths; normalizer converts to relative for Astro
-      image: z.preprocess(normalizeAssetPath(3), image().nullable().optional()),
-      flyer: z.preprocess(normalizeAssetPath(3), image().nullable().optional()),
+      // Media - TinaCMS Cloud saves /assets/... paths; served via public/assets symlink
+      image: z.string().nullable().optional(),
+      flyer: z.string().nullable().optional(),
       flyerPdf: z.string().nullable().optional(), // PDF version of flyer for download
 
       // Moto-Tally Integration
@@ -194,8 +179,7 @@ const eventsCollection = defineCollection({
  */
 const blogCollection = defineCollection({
   type: 'content',
-  schema: ({ image }) =>
-    z.object({
+  schema: z.object({
       title: z.string(),
       slug: z.string().optional(),
       pubDate: localDate,
@@ -205,7 +189,7 @@ const blogCollection = defineCollection({
       category: z.enum(BLOG_CATEGORIES).default('news'),
       image: z
         .object({
-          src: z.preprocess(normalizeAssetPath(2), image()),
+          src: z.string(),
           alt: z.string(),
         })
         .optional(),
@@ -251,12 +235,11 @@ const seriesCollection = defineCollection({
  */
 const boardCollection = defineCollection({
   type: 'content',
-  schema: ({ image }) =>
-    z.object({
+  schema: z.object({
       name: z.string(),
       title: z.string(),
       boardType: z.enum(['executive', 'trustees']).default('executive'),
-      image: z.preprocess(normalizeAssetPath(2), image().optional()),
+      image: z.string().optional(),
       email: z.string().email().optional(),
       phone: z.string().optional(),
       bio: z.string().optional(),
@@ -426,10 +409,9 @@ const siteInfoCollection = defineCollection({
  */
 const sponsorsCollection = defineCollection({
   type: 'content',
-  schema: ({ image }) =>
-    z.object({
+  schema: z.object({
       name: z.string(),
-      logo: z.preprocess(normalizeAssetPath(2), image()),
+      logo: z.string(),
       url: z.string().url().optional(),
       isTitleSponsor: z.boolean().default(false),
       order: z.number().default(0),

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -10,7 +10,7 @@ export interface Props {
   title: string;
   description?: string;
   image?: {
-    src: ImageMetadata;
+    src: string;
     alt: string;
   };
   date?: Date;
@@ -52,14 +52,23 @@ const formattedDate = date ? formatDate(date) : null;
 
     {(image || type === "blog") && (
       <div class="mb-8 overflow-hidden rounded-lg">
-        <Image
-          src={image?.src ?? defaultBlogImage}
-          alt={image?.alt ?? "ECEA"}
-          class={fullImage ? "w-full h-auto" : "object-cover w-full h-64 md:h-96"}
-          widths={[320, 640, 1024]}
-          format="webp"
-          loading="lazy"
-        />
+        {image?.src ? (
+          <img
+            src={image.src}
+            alt={image.alt}
+            loading="lazy"
+            class={fullImage ? "w-full h-auto" : "object-cover w-full h-64 md:h-96"}
+          />
+        ) : (
+          <Image
+            src={defaultBlogImage}
+            alt="ECEA"
+            loading="lazy"
+            class={fullImage ? "w-full h-auto" : "object-cover w-full h-64 md:h-96"}
+            widths={[320, 640, 1024]}
+            format="webp"
+          />
+        )}
       </div>
     )}
 

--- a/src/pages/board.astro
+++ b/src/pages/board.astro
@@ -3,7 +3,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import PageHeader from "../components/Sections/PageHeader.astro";
 import Button from "../components/UI/Button.astro";
 import { getCollection } from "astro:content";
-import { Image } from "astro:assets";
 import { STAFF_CATEGORIES } from "../utils/constants";
 
 // Get all board members
@@ -56,11 +55,10 @@ function encodeEmail(email: string): string {
         {officers.map((member) => (
           <div class="bg-white rounded-lg shadow-md p-6 text-center hover:shadow-lg transition-shadow">
             {member.data.image ? (
-              <Image
+              <img
                 src={member.data.image}
                 alt={member.data.name}
-                width={96}
-                height={96}
+                loading="lazy"
                 class="w-24 h-24 rounded-full object-cover mx-auto mb-4"
               />
             ) : (
@@ -106,11 +104,10 @@ function encodeEmail(email: string): string {
               <li class="flex items-center justify-between py-3 border-b border-gray-100 last:border-0">
                 <div class="flex items-center">
                   {trustee.data.image ? (
-                    <Image
+                    <img
                       src={trustee.data.image}
                       alt={trustee.data.name}
-                      width={40}
-                      height={40}
+                      loading="lazy"
                       class="w-10 h-10 rounded-full object-cover mr-4"
                     />
                   ) : (

--- a/src/pages/clubs/[slug].astro
+++ b/src/pages/clubs/[slug].astro
@@ -3,7 +3,6 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import PageHeader from "../../components/Sections/PageHeader.astro";
 import Button from "../../components/UI/Button.astro";
 import { getCollection, getEntry } from "astro:content";
-import { Image } from "astro:assets";
 
 // Generate static paths for all clubs
 export async function getStaticPaths() {
@@ -119,9 +118,10 @@ const clubMembers = [...clubMembersMap.values()].sort((a, b) => a.name.localeCom
             {
               entry.data.logo && (
                 <div class="mb-6 flex justify-center">
-                  <Image
+                  <img
                     src={entry.data.logo}
                     alt={entry.data.name}
+                    loading="lazy"
                     class="max-h-48 w-auto"
                   />
                 </div>

--- a/src/pages/clubs/index.astro
+++ b/src/pages/clubs/index.astro
@@ -2,7 +2,6 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import PageHeader from "../../components/Sections/PageHeader.astro";
 import { getCollection } from "astro:content";
-import { Image } from "astro:assets";
 
 // Fetch all clubs
 const all = await getCollection("clubs", ({ data }) =>
@@ -46,9 +45,10 @@ const clubs = all.sort((a, b) =>
             <!-- Club logo -->
             {m.data.logo && (
               <div class="w-full h-[200px] overflow-hidden bg-gray-100 flex items-center justify-center">
-                <Image
+                <img
                   src={m.data.logo}
                   alt={m.data.name}
+                  loading="lazy"
                   class="max-w-full max-h-full object-contain p-4"
                 />
               </div>

--- a/src/pages/events/[...slug].astro
+++ b/src/pages/events/[...slug].astro
@@ -39,9 +39,6 @@ if (!displayImage && entry.data.hostingClubs && entry.data.hostingClubs.length >
   }
 }
 
-// Check if displayImage is an ImageMetadata object (has .src property)
-const hasImageMetadata = displayImage && typeof displayImage === 'object' && 'src' in displayImage;
-
 // Get PDF flyer URL for download button (separate from image flyer)
 const flyerPdfUrl = entry.data.flyerPdf || null;
 
@@ -134,7 +131,7 @@ if (entry.data.eventType === "Enduro" && entry.data.hostingClubs?.[0]) {
   <PostLayout
     title={entry.data.title}
     description={entry.data.summary}
-    image={hasImageMetadata ? { src: displayImage, alt: entry.data.title } : undefined}
+    image={displayImage ? { src: displayImage, alt: entry.data.title } : undefined}
     date={entry.data.date}
     tags={entry.data.tags}
     type="event"


### PR DESCRIPTION
## Problem

TinaCMS Cloud saves image paths as absolute strings (`/assets/...` or `/uploads/...`). Astro's `image()` schema validator expects `ImageMetadata` objects from static imports — it rejects these string paths, causing build failures. Previous workaround (`normalizeAssetPath`) was fragile: URL encoding changes or depth mismatches broke it repeatedly.

## Solution

Replace `image()` with `z.string()` for all CMS-managed image fields in `src/content/config.ts`. Images are served as-is via the `public/assets → ../src/assets` symlink — no path conversion needed, no schema validator to break.

## Image optimization strategy

- **CMS images** (`/assets/...` strings): Use `<img loading="lazy">` — Astro cannot optimize public-directory string paths at build time
- **Static local assets** (imported as `ImageMetadata`): Keep `<Image>` component — full build-time WebP conversion, srcset, etc.

## Verification

Build passes: 295 pages, 33 images optimized (all static local assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)