### PR TITLE
Fix Netlify OOM: use --skip-indexing in build:tina

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "tinacms dev -c \"astro dev\"",
     "build": "astro build",
-    "build:tina": "tinacms build --skip-search-index && astro build",
+    "build:tina": "tinacms build --skip-indexing && astro build",
     "preview": "astro preview",
     "astro": "astro",
     "import-results": "node scripts/import-team-results.mjs"


### PR DESCRIPTION
## Summary
- Replaces `--skip-search-index` with `--skip-indexing` in the `build:tina` script
- `--skip-search-index` only skips the search index step; the OOM was happening during TinaCloud **content** indexing (streaming reindex response accumulates 2GB+ heap)
- `--skip-indexing` decouples the build from TinaCloud's indexing process entirely — TinaCloud reindexes via GitHub webhook independently after the push

## Test plan
- [ ] Netlify build completes without OOM on master
- [ ] TinaCloud content still accessible in CMS after deploy (indexed via webhook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)