### PR TITLE
Fix Netlify OOM: use --skip-cloud-checks in build:tina

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "tinacms dev -c \"astro dev\"",
     "build": "astro build",
-    "build:tina": "tinacms build --skip-indexing && astro build",
+    "build:tina": "tinacms build --skip-cloud-checks && astro build",
     "preview": "astro preview",
     "astro": "astro",
     "import-results": "node scripts/import-team-results.mjs"


### PR DESCRIPTION
## Root cause
The OOM was caused by `waitForDB()`, a polling loop inside TinaCMS CLI's cloud check block. It polls TinaCloud every 5s waiting for indexing to complete, and each poll accumulates state in a `Map` that grows until the 2GB default heap is exhausted.

`--skip-indexing` only skips self-hosted TinaCMS indexing — it has **no effect** on the TinaCloud `waitForDB` polling loop.

## Fix
`--skip-cloud-checks` bypasses the entire `!skipCloudChecks` block, which contains:
- `checkClientInfo`
- `waitForDB` ← the OOM source
- `checkGraphqlSchema`

The admin panel is still generated. TinaCloud reindexes via GitHub webhook independently after the push.

## Test plan
- [ ] Netlify build completes without OOM
- [ ] `/admin` panel loads and connects to TinaCloud normally
- [ ] Content edits via TinaCMS continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)