### PR TITLE
docs: update READMEs for current architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The official website for the East Coast Enduro Association, built with Astro and
 ```
 src/
 ├── assets/               # Images processed by Astro (optimized at build)
+│   ├── blog/             # Blog post images
+│   ├── board/photos/     # Board member photos
 │   ├── clubs/logos/      # Club logos
 │   ├── ecea/logos/       # ECEA organization logos
 │   ├── events/flyers/    # Event flyers
@@ -29,25 +31,39 @@ src/
 │   ├── blog/             # Blog posts and announcements
 │   ├── board/            # Board members (executive + trustees)
 │   ├── clubs/            # Club profiles
-│   ├── events/           # Events by year (2023-2026)
+│   ├── events/           # Events by year (2023–present)
+│   ├── faqPage/          # FAQ page content
+│   ├── getStartedPage/   # Get Started page content
 │   ├── members/          # Membership data (JSON)
-│   ├── pages/            # Static page content
 │   ├── series/           # Racing series info
+│   ├── siteInfo/         # Global site config
 │   ├── sponsors/         # Sponsor logos and info
 │   ├── staff/            # Staff contacts by category
+│   ├── teamEventResults/ # Per-event team competition results (JSON)
 │   ├── teamResults/      # Team competition standings (JSON)
+│   ├── teamSeasons/      # Team season schedules (JSON)
 │   └── config.ts         # Content collection schemas
 ├── layouts/              # Page layouts
 ├── pages/                # Astro pages (routes)
 ├── scripts/              # Client-side TypeScript
-└── utils/                # Utilities and constants
+└── utils/
+    ├── cmsImage.ts       # Resolves CMS image paths to Astro ImageMetadata
+    └── constants.ts      # Site config, navigation, series links
 
 tina/
-├── config.ts             # TinaCMS schema configuration
-└── CustomLogo.tsx        # Custom admin branding
+├── collections/          # One file per TinaCMS collection
+│   ├── blog.ts, board.ts, clubs.ts, events.ts
+│   ├── faqPage.ts, getStartedPage.ts, series.ts
+│   ├── siteInfo.ts, sponsors.ts, staff.ts
+│   ├── teamEventResults.ts, teamResults.ts, teamSeasons.ts
+├── config.tsx            # TinaCMS entry point — imports collections, sets media config
+├── helpers.ts            # Shared field helpers (richText, imageField, etc.)
+├── components.tsx        # Custom TinaCMS UI components
+├── CsvUploaderScreen.tsx # Custom screen for uploading team results CSVs
+└── tina-lock.json        # Schema lock file — must be committed
 
 public/
-├── admin/                # TinaCMS admin (built)
+├── admin/                # TinaCMS admin SPA (pre-built, committed to git)
 ├── assets -> ../src/assets  # Symlink — keeps TinaCMS preview URLs working locally
 ├── attachments/          # PDFs and downloads
 ├── documents/            # Rulebook, welcome book, forms
@@ -56,36 +72,35 @@ public/
 
 ## Content Collections
 
-| Collection | Description | CMS-Managed |
-|------------|-------------|-------------|
-| `blog/` | News, announcements, recaps | ✅ |
-| `events/` | Race events by year | ✅ |
-| `clubs/` | 19 member club profiles | ✅ |
-| `series/` | Enduro, Hare Scramble, FastKIDZ, Dual Sport | ✅ |
-| `board/` | Executive board + Board of Trustees | ✅ |
-| `staff/` | Series directors, referees, contacts | ✅ |
-| `sponsors/` | Title + regular sponsors | ✅ |
-| `teamResults/` | Enduro team competition standings | ✅ |
-| `pages/` | Static page content (Get Started, FAQ) | ✅ |
+| Collection | Description |
+|------------|-------------|
+| `blog/` | News, announcements, recaps |
+| `events/` | Race events by year |
+| `clubs/` | Member club profiles |
+| `series/` | Enduro, Hare Scramble, FastKIDZ, Dual Sport |
+| `board/` | Executive board + Board of Trustees |
+| `staff/` | Series directors, referees, contacts |
+| `sponsors/` | Title + regular sponsors |
+| `teamEventResults/` | Per-event team competition results |
+| `teamResults/` | Team competition standings |
+| `teamSeasons/` | Team season schedules |
+| `faqPage/` | FAQ page content |
+| `getStartedPage/` | Get Started page content |
+| `siteInfo/` | Global site config |
 
 ## Getting Started
 
 ### Prerequisites
 
-- Node.js 18 or later
-- npm, yarn, or pnpm
+- Node.js 20 or later
+- npm
 
 ### Installation
 
 ```bash
-# Clone the repository
 git clone https://github.com/east-coast-enduro-association/ecea-ui.git
 cd ecea-ui
-
-# Install dependencies
 npm install
-
-# Start development server
 npm run dev
 ```
 
@@ -96,9 +111,10 @@ Open your browser to `http://localhost:4321`
 | Command | Description |
 |---------|-------------|
 | `npm run dev` | Start dev server with TinaCMS local mode |
-| `npm run build:tina` | Build TinaCMS admin + Astro site (used in production) |
-| `npm run build` | Build Astro site only (skips TinaCMS admin) |
+| `npm run build` | Build Astro site only (used by Netlify) |
+| `npm run build:tina` | Rebuild TinaCMS admin panel + Astro site (run locally after tina config changes) |
 | `npm run preview` | Preview production build locally |
+| `npm run import-results` | Import team results CSV manually |
 
 ## TinaCMS Admin
 
@@ -108,120 +124,62 @@ Access the CMS admin at `/admin` to manage content visually.
 ```bash
 npm run dev
 # Navigate to http://localhost:4321/admin
+# Uses local mode — no cloud authentication required
 ```
 
 ### Production
 The admin is available at `https://ecea.org/admin` (requires GitHub authentication).
 
-### What You Can Edit
+## How Deploys Work
 
-- **Blog Posts** - Create/edit news, announcements, recaps
-- **Events** - Add events with flyers, registration links, Moto-Tally IDs
-- **Clubs** - Update club info, logos, contacts
-- **Board Members** - Executive board and Board of Trustees
-- **Staff Contacts** - Series directors, referees, coordinators
-- **Sponsors** - Add/remove sponsors, set title sponsor
-- **Team Results** - Update enduro team competition standings
-- **Series Pages** - Edit series descriptions and documents
-
-## Adding Content
-
-### Via TinaCMS (Recommended)
-1. Go to `/admin`
-2. Select the collection (Blog, Events, etc.)
-3. Click "Create New" or edit existing
-4. Save changes (commits to git automatically)
-
-### Via Markdown Files
-
-Create files directly in `src/content/`. Each collection has a schema in `src/content/config.ts`.
-
-**Blog Post Example** (`src/content/blog/2025-01-15-post-title.md`):
-```markdown
----
-title: "Your Post Title"
-pubDate: 2025-01-15
-description: "Brief description for previews"
-author: "ECEA"
-category: "announcement"
-tags: ["news"]
-draft: false
-pinned: false
----
-
-Your content in Markdown...
+```
+Editor saves in TinaCMS UI
+        ↓
+TinaCMS Cloud → GitHub commit (markdown/JSON + any uploaded images)
+        ↓
+Netlify detects push → runs `npm run build` (astro build only)
+        ↓
+Site rebuilds and deploys (~1 min)
 ```
 
-**Event Example** (`src/content/events/2025/event-name.md`):
-```markdown
----
-title: "Event Name Enduro"
-date: 2025-03-15
-location: "Location, PA"
-hostingClubs: ["CLUB"]
-eventType: "Enduro"
-motoTallyId: 5
-draft: false
----
+Netlify runs `astro build` only — `tinacms build` is **not** run at deploy time. The TinaCMS admin panel (`public/admin/`) is pre-built and committed to the repo. Only rebuild it locally when the tina schema changes:
+
+```bash
+npm run build:tina
+git add public/admin/
+git commit -m "Rebuild TinaCMS admin panel"
+git push
 ```
+
+## Image Handling
+
+All CMS-managed images are stored in `src/assets/` and committed to the repo (TinaCMS uploads directly via the GitHub API). Astro optimizes them at build time.
+
+Image fields in `src/content/config.ts` use `z.string()`. The `getCmsImage()` utility in `src/utils/cmsImage.ts` resolves any string path to Astro `ImageMetadata` using `import.meta.glob`. Components use `<Image>` when the metadata resolves and fall back to `<img>` for unresolved paths.
+
+Supported path formats:
+
+| Format | Example |
+|--------|---------|
+| Absolute (TinaCMS Cloud) | `/assets/events/flyers/foo.jpg` |
+| Relative (legacy) | `../../../assets/events/flyers/foo.jpg` |
+| Alias | `@assets/events/flyers/foo.jpg` |
 
 ## Configuration
 
 ### Site Constants (`src/utils/constants.ts`)
 
-- `SITE_INFO` - Site name, tagline, contact
-- `NAV_ITEMS` - Main navigation
-- `FOOTER_NAV` - Footer link groups
-- `SERIES_LINKS` - Homepage series quick links
-- `FACEBOOK_GROUPS` - Community links
-- `STAFF_CATEGORIES` - Staff contact groupings
-- `MOTO_TALLY` - Results/registration URL config
+- `SITE_INFO` — Site name, tagline, contact
+- `NAV_ITEMS` — Main navigation
+- `FOOTER_NAV` — Footer link groups
+- `SERIES_LINKS` — Homepage series quick links
+- `FACEBOOK_GROUPS` — Community links
+- `STAFF_CATEGORIES` — Staff contact groupings
+- `MOTO_TALLY` — Results/registration URL config
 
 ### Moto-Tally Integration
 
-Events with a `motoTallyId` automatically get links to:
-- Registration
-- Start Grid
-- Results
-
-Configure base URLs in `MOTO_TALLY` constant.
-
-## Features
-
-### Events Calendar
-- Visual mini calendar with event dots
-- Click dots to see event tooltips
-- iCal/Google Calendar export
-
-### Results Integration
-- Links to Moto-Tally for official results
-- Enduro team competition standings
-- Historical results by year
-
-### Get Started Flow
-- Highlighted in navigation
-- Step-by-step guide for new racers
-- Links to series info and registration
-
-## Deployment
-
-Deploys automatically via Netlify on push to `master`.
-
-**Build Settings:**
-- Build command: `npm run build:tina`
-- Publish directory: `dist`
-- Node version: 20+
-
-## Testing Checklist
-
-- [ ] Navigation - All links work, mobile menu functions
-- [ ] Events - Filters, pagination, calendar export
-- [ ] Blog - Category filter, pagination
-- [ ] Board/Contact - Staff contacts display correctly
-- [ ] Sponsors - Carousel displays all sponsors
-- [ ] TinaCMS - Admin loads, can edit content
-- [ ] Responsive - Mobile, tablet, desktop layouts
-- [ ] Build - `npm run build` completes without errors
+Events with a `motoTallyId` automatically get links to registration, start grid, and results. Configure base URLs in `MOTO_TALLY` in `constants.ts`.
 
 ## Key Files
 
@@ -229,16 +187,22 @@ Deploys automatically via Netlify on push to `master`.
 |------|---------|
 | `src/content/config.ts` | Content collection schemas |
 | `src/utils/constants.ts` | Site config, navigation |
-| `tina/config.ts` | TinaCMS schema config |
+| `src/utils/cmsImage.ts` | CMS image path → Astro ImageMetadata |
+| `tina/config.tsx` | TinaCMS entry point |
+| `tina/collections/` | Per-collection TinaCMS schemas |
+| `tina/helpers.ts` | Shared TinaCMS field helpers |
+| `tina/tina-lock.json` | Schema lock file (must be committed) |
 | `tailwind.config.cjs` | Tailwind customization |
 | `astro.config.mjs` | Astro configuration |
+| `netlify.toml` | Netlify build + header/redirect config |
 
 ## Contributing
 
 1. Create a feature branch
-2. Make changes and test locally
-3. Run `npm run build` to verify
-4. Submit a pull request
+2. Make changes and test locally (`npm run dev`)
+3. Run `npm run build` to verify the site builds cleanly
+4. If you changed anything in `tina/`, also run `npm run build:tina` and commit `public/admin/`
+5. Submit a pull request to `master`
 
 ## Support
 

--- a/src/content/README.md
+++ b/src/content/README.md
@@ -13,74 +13,68 @@ All site content lives here as Markdown (`.md`) or JSON files. Schemas are defin
 | `board/` | Markdown | Executive board + Board of Trustees |
 | `staff/` | Markdown | Series directors, referees, contacts |
 | `sponsors/` | Markdown | Title and regular sponsors |
-| `pages/` | Markdown | Static page content (Get Started, FAQ) |
+| `faqPage/` | Markdown | FAQ page content |
+| `getStartedPage/` | Markdown | Get Started page content |
 | `siteInfo/` | Markdown | Global site config |
-| `teamResults/` | JSON | Enduro team competition standings |
+| `teamEventResults/` | JSON | Per-event team competition results |
+| `teamResults/` | JSON | Team competition standings |
+| `teamSeasons/` | JSON | Team season schedules |
 | `members/` | JSON | Membership roster by series/year |
 
-## Image Path Normalization
+## Image Fields
 
-### The Problem
+Image fields in `config.ts` use `z.string()` rather than Astro's `image()` validator. This is intentional — TinaCMS Cloud saves image paths as absolute strings (e.g. `/assets/events/flyers/foo.jpg`), which are incompatible with the `image()` validator's static import requirement.
 
-TinaCMS Cloud saves image paths as absolute paths like:
-```
-/assets/events/flyers/my-flyer.jpg
-```
+At render time, `getCmsImage()` in `src/utils/cmsImage.ts` resolves any path to Astro `ImageMetadata` using an eager `import.meta.glob` over all of `src/assets/`. This gives full Astro image optimization (format conversion, responsive sizes, lazy loading) for all CMS-managed images. If a path doesn't resolve (e.g. an external URL), components fall back to a plain `<img>`.
 
-Astro's `image()` schema validator requires relative paths:
-```
-../../../assets/events/flyers/my-flyer.jpg
-```
+Supported path formats (all normalize correctly):
 
-### The Fix
-
-`config.ts` defines a `normalizeAssetPath(depth)` helper that preprocesses image values before `image()` validates them:
-
-```ts
-const normalizeAssetPath = (depth: number) => (val: unknown) => {
-  if (typeof val === 'string') {
-    if (val === '') return undefined;
-    if (val.startsWith('/assets/')) {
-      return '../'.repeat(depth) + 'assets/' + val.slice(8);
-    }
-  }
-  return val;
-};
-```
-
-It's applied as a `z.preprocess` wrapper on every `image()` field:
-
-```ts
-flyer: z.preprocess(normalizeAssetPath(3), image().nullable().optional()),
-```
-
-The `depth` parameter is the number of directory levels from the content file up to `src/`:
-
-| Collection path | Depth | Prefix |
-|----------------|-------|--------|
-| `src/content/events/YEAR/` | 3 | `../../../` |
-| `src/content/blog/` | 2 | `../../` |
-| `src/content/clubs/` | 2 | `../../` |
-| `src/content/board/` | 2 | `../../` |
-| `src/content/sponsors/` | 2 | `../../` |
-
-Existing relative paths (already in `../../..` format) pass through unchanged.
+| Format | Example |
+|--------|---------|
+| Absolute (TinaCMS Cloud) | `/assets/events/flyers/foo.jpg` |
+| Relative (legacy) | `../../../assets/events/flyers/foo.jpg` |
+| Alias | `@assets/events/flyers/foo.jpg` |
 
 ## Adding a New Image Field
 
-If you add an image field to a collection schema, wrap it with `normalizeAssetPath`:
+In `config.ts`, use `z.string()`:
 
 ```ts
-// Events collection (depth 3)
-myImage: z.preprocess(normalizeAssetPath(3), image().nullable().optional()),
+// Optional image
+myImage: z.string().nullable().optional(),
 
-// Other collections (depth 2)
-myImage: z.preprocess(normalizeAssetPath(2), image().nullable().optional()),
+// Required image
+myImage: z.string(),
 ```
+
+In the component, resolve and use `<Image>`:
+
+```astro
+import { Image } from "astro:assets";
+import { getCmsImage } from "../../utils/cmsImage";
+
+const imageMeta = getCmsImage(myImage);
+---
+{imageMeta ? (
+  <Image src={imageMeta} alt="..." />
+) : myImage ? (
+  <img src={myImage} alt="..." loading="lazy" />
+) : null}
+```
+
+## Schema Helpers
+
+Defined at the top of `config.ts`:
+
+| Helper | Purpose |
+|--------|---------|
+| `localDate` | Parses dates as local time (prevents UTC timezone shift) |
+| `optionalString` | Optional string that treats empty string as `undefined` |
+| `optionalUrl` | Optional string validated as a URL |
 
 ## Event Content
 
-Events are organized by year under `events/YEAR/`. All years share the same schema (defined once in `config.ts` as `eventsCollection`).
+Events are organized by year under `events/YEAR/`. All years share the same schema (`eventsCollection` in `config.ts`).
 
 ### Filename Convention
 
@@ -95,14 +89,5 @@ Type abbreviations: `en` = Enduro, `hs` = Hare Scramble, `fk` = FastKIDZ, `ds` =
 ### Flyer Images
 
 Flyer images are stored in `src/assets/events/flyers/`. To add a flyer:
-- **Via TinaCMS (recommended):** Use the image picker in the event editor — the file will be committed automatically
-- **Manually:** Add the file to `src/assets/events/flyers/` and set `flyer: ../../../assets/events/flyers/your-file.jpg` in the frontmatter
-
-## Schema Helpers
-
-| Helper | Purpose |
-|--------|---------|
-| `localDate` | Parses dates as local time (prevents UTC timezone shift) |
-| `optionalString` | Optional string that treats empty string as `undefined` |
-| `optionalUrl` | Optional string validated as a URL |
-| `normalizeAssetPath(depth)` | Normalizes TinaCMS absolute image paths to relative |
+- **Via TinaCMS (recommended):** Use the image picker in the event editor — the file commits automatically
+- **Manually:** Add the file to `src/assets/events/flyers/` and set `flyer: /assets/events/flyers/your-file.jpg` in the frontmatter

--- a/tina/README.md
+++ b/tina/README.md
@@ -4,12 +4,15 @@ This directory contains the TinaCMS schema and admin branding for the ECEA websi
 
 ## Files
 
-| File | Purpose |
-|------|---------|
-| `config.tsx` | All collection schemas, field definitions, and media config |
-| `CsvUploaderScreen.tsx` | Custom TinaCMS screen for uploading team results CSVs |
+| File/Directory | Purpose |
+|----------------|---------|
+| `config.tsx` | TinaCMS entry point — imports all collections, sets media config |
+| `collections/` | One file per collection (blog, events, clubs, etc.) |
+| `helpers.ts` | Shared field helpers (richText, imageField, uploadDir, etc.) |
+| `components.tsx` | Custom TinaCMS UI components |
+| `CsvUploaderScreen.tsx` | Custom screen for uploading team results CSVs |
 | `tina-lock.json` | Compiled schema snapshot — **must be committed** |
-| `__generated__/` | Auto-generated types/client — gitignored, rebuilt at build time |
+| `__generated__/` | Auto-generated types/client — gitignored, rebuilt locally |
 
 ## How TinaCMS Works Here
 
@@ -20,7 +23,7 @@ Editor saves in TinaCMS UI
         ↓
 TinaCMS Cloud → GitHub commit (markdown/JSON + any uploaded images)
         ↓
-Netlify detects push → runs `npm run build:tina`
+Netlify detects push → runs `npm run build` (astro build only)
         ↓
 Site rebuilds and deploys
 ```
@@ -57,47 +60,62 @@ TinaCMS uploads images directly to `src/assets/...` in the GitHub repo. Each ima
 
 The `public/assets` symlink still exists for local dev — it lets TinaCMS admin preview images at `/assets/...` URLs while running locally.
 
-### Why `ui.parse` Is Not Used
+### Image Paths in Content Files
 
-TinaCMS's `ui.parse` function (which appears on image fields) is a **client-side-only** transform. TinaCMS Cloud does not apply it when saving content via the API — the raw path from the media picker is written directly to the markdown file.
+TinaCMS Cloud saves image paths as absolute strings like `/assets/events/flyers/foo.jpg`. All image fields in `src/content/config.ts` use `z.string()` to accept these directly.
 
-Path normalization (converting TinaCMS's `/assets/...` paths to Astro-compatible relative paths) is handled instead by `normalizeAssetPath` in `src/content/config.ts`.
+At render time, `getCmsImage()` in `src/utils/cmsImage.ts` resolves any path variant to Astro `ImageMetadata` via `import.meta.glob`, enabling full Astro image optimization. It handles three formats:
 
-## tina-lock.json
-
-This file is a compiled snapshot of the schema used by TinaCMS Cloud to validate builds. It **must be kept in sync** with `config.ts`. If you change `config.ts` (add a field, change media config, etc.), the lock file is normally updated automatically when `tinacms build` runs — but if you make changes manually to `config.ts`, you may need to run `tinacms build` locally to regenerate it.
-
-If a Netlify build fails with:
-> "The local Tina schema doesn't match the remote Tina schema"
-
-it usually means `tina-lock.json` is out of sync with `config.tsx`. The reliable fix is to run `npm run dev` locally (not `build:tina`) — the dev server regenerates `tina-lock.json` to match the current config. Commit and push the updated file, then trigger a re-index from the TinaCloud dashboard.
+| Format | Example |
+|--------|---------|
+| Absolute (TinaCMS Cloud) | `/assets/events/flyers/foo.jpg` |
+| Relative (legacy) | `../../../assets/events/flyers/foo.jpg` |
+| Alias | `@assets/events/flyers/foo.jpg` |
 
 ### Attachment Files (PDFs)
 
-The downloads field on events uploads files to `src/attachments/events/` (because `publicFolder: 'src'`). However, PDFs need to be in `public/attachments/events/` to be served by the site.
+The downloads field on events uses `publicFolder: 'src'`, so TinaCMS uploads PDFs to `src/attachments/events/`. However, PDFs need to be in `public/attachments/events/` to be served.
 
-**`.rs` files (Enduro Roll Chart):** TinaCMS's media picker does not allow `.rs` uploads. Copy these files to `src/attachments/events/` via git and add the URL directly to the event's `downloads` array in the markdown file. Everything else (PDFs, images) uploads normally through TinaCMS.
-
-**Current workaround for PDFs:** After TinaCMS uploads an attachment, manually move it:
+**After TinaCMS uploads an attachment**, move it:
 ```bash
 git mv "src/attachments/events/your-file.pdf" "public/attachments/events/your-file.pdf"
 git commit -m "Move attachment to public/"
 git push
 ```
 
-The URL saved in the event's `downloads[].url` field (e.g., `/attachments/events/your-file.pdf`) will work once the file is in `public/`.
+**`.rs` files (Enduro Roll Charts):** TinaCMS's media picker does not allow `.rs` uploads. Copy these files to `public/attachments/events/` via git and add the URL directly to the event's `downloads` array in the markdown file.
+
+## tina-lock.json
+
+This file is a compiled snapshot of the schema used by TinaCMS Cloud to validate builds. It **must be kept in sync** with `config.tsx` and committed. If you change the config (add a field, rename a collection, etc.), run `npm run dev` locally — the dev server regenerates `tina-lock.json` automatically. Commit and push the updated file.
+
+If a Netlify build or TinaCloud sync fails with a schema mismatch error, the lock file is likely out of sync. Fix by running `npm run dev` locally, committing the regenerated `tina-lock.json`, and pushing.
+
+## Admin Panel
+
+The TinaCMS admin panel (`public/admin/`) is a static SPA that is **pre-built and committed** to the repo. Netlify does not run `tinacms build` at deploy time — it only runs `astro build`.
+
+The admin panel only needs to be rebuilt when the tina schema changes. After any schema change:
+
+```bash
+npm run build:tina
+git add public/admin/
+git commit -m "Rebuild TinaCMS admin panel"
+git push
+```
 
 ## Adding a New Collection
 
-1. Define the collection in `config.tsx` using `defineConfig`
-2. For image fields, use `uploadDir` and wrap with the path type — **do not rely on `ui.parse`**; path normalization happens in `src/content/config.ts`
-3. Add the collection to `src/content/config.ts` with the appropriate schema
+1. Create `tina/collections/your-collection.ts` — define the collection using `defineConfig` helpers
+2. Import and add it to the `collections` array in `tina/config.tsx`
+3. Add the corresponding collection to `src/content/config.ts` with `z.string()` for image fields
 4. Run `npm run dev` locally to regenerate `tina-lock.json`
-5. Commit both `config.tsx` and `tina-lock.json`
+5. Run `npm run build:tina` to rebuild the admin panel
+6. Commit `tina/collections/your-collection.ts`, `tina/tina-lock.json`, `src/content/config.ts`, and `public/admin/`
 
 ## Visual Editing
 
-Visual editing is intentionally **disabled**. The `router` config has been removed from all collections (events, blog, clubs, series). Adding a `router` field to any collection re-enables visual editing mode in the TinaCMS admin — avoid this unless intentional.
+Visual editing is intentionally **disabled**. The `router` config has been removed from all collections. Adding a `router` field to any collection re-enables visual editing mode — avoid this unless intentional.
 
 ## Local Development
 
@@ -105,6 +123,5 @@ Visual editing is intentionally **disabled**. The `router` config has been remov
 npm run dev
 # TinaCMS admin available at http://localhost:4321/admin
 # Uses local mode — no cloud authentication required
+# Changes are written to your local filesystem instead of GitHub
 ```
-
-In local mode, changes are written directly to your local filesystem instead of GitHub.


### PR DESCRIPTION
Updates the three main README files to reflect all recent changes.

**README.md**
- Updated project structure (modularized `tina/collections/`, `faqPage/`, `getStartedPage/`, `utils/cmsImage.ts`)
- Build process: Netlify now runs `astro build` only; `build:tina` is for local schema changes
- Image handling: `z.string()` + `getCmsImage()` replacing the old `normalizeAssetPath` approach
- Updated contributing workflow (rebuild admin panel when tina config changes)

**tina/README.md**
- Updated file listing for modularized collections
- Removed outdated `normalizeAssetPath` and `ui.parse` sections
- Added pre-committed admin panel workflow
- Updated "adding a new collection" guide

**src/content/README.md**
- Replaced `normalizeAssetPath` section with `getCmsImage()` approach
- Updated collections list (`faqPage/`, `getStartedPage/`, `siteInfo/`, `teamSeasons/` added)
- Simplified image field guidance with correct `z.string()` pattern

No changes to `scripts/README.md`, `uploads/team-results/README.md`, or `src/content/teamEventResults/README.md` — those are still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)