### PR TITLE
Add GitHub org link to navigation

### DIFF
--- a/src/components/Global/Navigation.astro
+++ b/src/components/Global/Navigation.astro
@@ -247,6 +247,22 @@ const signupDropdown = [
         </svg>
       </a>
     </li>
+
+    <!-- GitHub Icon - Links to ECEA GitHub organization -->
+    <li>
+      <a
+        href="https://github.com/east-coast-enduro-association"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-gray-700 hover:text-primary-600 transition-colors p-2"
+        aria-label="ECEA GitHub Organization"
+        title="ECEA on GitHub"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
+        </svg>
+      </a>
+    </li>
   </ul>
 </nav>
 
@@ -300,17 +316,29 @@ const signupDropdown = [
       }
     </div>
 
-    <!-- Facebook Link -->
-    <div class="mt-4 pt-4 border-t border-gray-100">
+    <!-- Social Links -->
+    <div class="mt-4 pt-4 border-t border-gray-100 flex gap-2">
       <a
         href="/resources#community"
-        class="flex items-center justify-center px-4 py-3 text-sm font-medium text-gray-600 hover:text-primary-600 transition-colors rounded-lg hover:bg-gray-50"
+        class="flex-1 flex items-center justify-center px-4 py-3 text-sm font-medium text-gray-600 hover:text-primary-600 transition-colors rounded-lg hover:bg-gray-50"
         role="menuitem"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="currentColor" viewBox="0 0 24 24">
           <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
         </svg>
-        ECEA Facebook Groups
+        Facebook
+      </a>
+      <a
+        href="https://github.com/east-coast-enduro-association"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex-1 flex items-center justify-center px-4 py-3 text-sm font-medium text-gray-600 hover:text-primary-600 transition-colors rounded-lg hover:bg-gray-50"
+        role="menuitem"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
+        </svg>
+        GitHub
       </a>
     </div>
   </div>


### PR DESCRIPTION
Adds a GitHub icon button next to the Facebook icon in both desktop and mobile navigation, linking to https://github.com/east-coast-enduro-association.

- Desktop: icon-only button matching the Facebook icon style
- Mobile: side-by-side with Facebook, labeled "Facebook" / "GitHub"

🤖 Generated with [Claude Code](https://claude.com/claude-code)