### PR TITLE
Widen .container to fix smushed nav on widescreen

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -42,7 +42,7 @@
 
 @layer components {
   .container {
-    @apply px-4 mx-auto max-w-7xl;
+    @apply px-4 mx-auto max-w-screen-2xl;
   }
 
   .btn {


### PR DESCRIPTION
## Summary
- Bumps the global \`.container\` max-width from \`max-w-7xl\` (1280px) to \`max-w-screen-2xl\` (1536px) in \`src/assets/styles/global.css\`.
- Header (logo + nav) was getting crammed into 1280px on widescreen monitors while the page around it was wider — now it uses more of the viewport.
- Affects every page that uses \`.container\` (heroes, article bodies, etc.), not just the nav, since they share the same utility class.

## Test plan
- [ ] Open the site on a >1280px-wide monitor and confirm the header logo + nav no longer feel smushed.
- [ ] Spot-check the homepage hero and a few article pages — wider container should still look balanced, not stretched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)